### PR TITLE
UncaughtExceptionHandler looses events on crash

### DIFF
--- a/tracker/src/main/java/org/matomo/sdk/Tracker.java
+++ b/tracker/src/main/java/org/matomo/sdk/Tracker.java
@@ -201,6 +201,14 @@ public class Tracker {
     }
 
     /**
+     * Process all queued events and block until processing is complete
+     */
+    public void dispatchBlocking() {
+        if (mOptOut) return;
+        mDispatcher.forceDispatchBlocking();
+    }
+
+    /**
      * Set the interval to 0 to dispatch events as soon as they are queued.
      * If a negative value is used the dispatch timer will never run, a manual dispatch must be used.
      *

--- a/tracker/src/main/java/org/matomo/sdk/Tracker.java
+++ b/tracker/src/main/java/org/matomo/sdk/Tracker.java
@@ -193,6 +193,15 @@ public class Tracker {
     }
 
     /**
+     * For the Dispatcher to run in offline mode.  This will send all tracked events to disk until the next time the tracker is constructed.
+     *
+     * @see Dispatcher#setOffline()
+     */
+    public void setOffline() {
+        mDispatcher.setOffline();
+    }
+
+    /**
      * Processes all queued events in background thread
      */
     public void dispatch() {

--- a/tracker/src/main/java/org/matomo/sdk/dispatcher/DefaultDispatcher.java
+++ b/tracker/src/main/java/org/matomo/sdk/dispatcher/DefaultDispatcher.java
@@ -168,7 +168,7 @@ public class DefaultDispatcher implements Dispatcher {
             try {
                 dispatchThread.join();
             } catch (InterruptedException e) {
-                Timber.tag(TAG).i("Interrupted while waiting for dispatch thread to complete");
+                Timber.tag(TAG).d("Interrupted while waiting for dispatch thread to complete");
             }
         }
 

--- a/tracker/src/main/java/org/matomo/sdk/dispatcher/DefaultDispatcher.java
+++ b/tracker/src/main/java/org/matomo/sdk/dispatcher/DefaultDispatcher.java
@@ -203,7 +203,7 @@ public class DefaultDispatcher implements Dispatcher {
                     // Either we wait the interval or forceDispatch() granted us one free pass
                     mSleepToken.tryAcquire(sleepTime, TimeUnit.MILLISECONDS);
                 } catch (InterruptedException e) {Timber.tag(TAG).e(e); }
-                if (mEventCache.updateState(isConnected())) {
+                if (mEventCache.updateState(isOnline())) {
                     int count = 0;
                     List<Event> drainedEvents = new ArrayList<>();
                     mEventCache.drainTo(drainedEvents);
@@ -222,7 +222,7 @@ public class DefaultDispatcher implements Dispatcher {
                             count += packet.getEventCount();
                             mRetryCounter = 0;
                         } else {
-                            // On network failure, requeue all un-sent events, but use isConnected to determine if events should be cached in
+                            // On network failure, requeue all un-sent events, but use isOnline to determine if events should be cached in
                             // memory or disk
                             Timber.tag(TAG).d("Failure while trying to send packet");
                             mRetryCounter++;
@@ -231,7 +231,7 @@ public class DefaultDispatcher implements Dispatcher {
 
                         // Re-check network connectivity to early exit if we drop offline.  This speeds up how quickly the setOffline method will
                         // take effect
-                        if (!isConnected()) {
+                        if (!isOnline()) {
                             Timber.tag(TAG).d("Disconnected during dispatch loop");
                             break;
                         }
@@ -244,7 +244,7 @@ public class DefaultDispatcher implements Dispatcher {
                         // events are requeued we update the event cache state to write the requeued events to disk or to leave them in memory
                         // depending on the connectivity state of the device.
                         mEventCache.requeue(drainedEvents.subList(count, drainedEvents.size()));
-                        mEventCache.updateState(isConnected());
+                        mEventCache.updateState(isOnline());
                     }
                 }
 
@@ -260,7 +260,7 @@ public class DefaultDispatcher implements Dispatcher {
         }
     };
 
-    private boolean isConnected() {
+    private boolean isOnline() {
         if (mForceOffline || !mConnectivity.isConnected()) return false;
 
         switch (mDispatchMode) {

--- a/tracker/src/main/java/org/matomo/sdk/dispatcher/DefaultDispatcher.java
+++ b/tracker/src/main/java/org/matomo/sdk/dispatcher/DefaultDispatcher.java
@@ -39,7 +39,6 @@ public class DefaultDispatcher implements Dispatcher {
 
     private boolean mDispatchGzipped = false;
     private volatile DispatchMode mDispatchMode = DispatchMode.ALWAYS;
-    private volatile boolean mForceOffline = false;
     private volatile boolean mRunning = false;
     @Nullable private volatile Thread mDispatchThread = null;
     private List<Packet> mDryRunTarget = null;
@@ -116,11 +115,6 @@ public class DefaultDispatcher implements Dispatcher {
     @Override
     public DispatchMode getDispatchMode() {
         return mDispatchMode;
-    }
-
-    @Override
-    public void setOffline() {
-        mForceOffline = true;
     }
 
     private boolean launch() {
@@ -261,9 +255,11 @@ public class DefaultDispatcher implements Dispatcher {
     };
 
     private boolean isOnline() {
-        if (mForceOffline || !mConnectivity.isConnected()) return false;
+        if (!mConnectivity.isConnected()) return false;
 
         switch (mDispatchMode) {
+            case EXCEPTION:
+                return false;
             case ALWAYS:
                 return true;
             case WIFI_ONLY:

--- a/tracker/src/main/java/org/matomo/sdk/dispatcher/DispatchMode.java
+++ b/tracker/src/main/java/org/matomo/sdk/dispatcher/DispatchMode.java
@@ -11,7 +11,12 @@ public enum DispatchMode {
     /**
      * Dispatch only on WIFI
      */
-    WIFI_ONLY("wifi_only");
+    WIFI_ONLY("wifi_only"),
+    /**
+     * The dispatcher will assume being offline. This is not persisted and will revert on app restart.
+     * Ensures no information is lost when tracking exceptions. See #247
+     */
+    EXCEPTION("exception");
 
     private final String key;
 

--- a/tracker/src/main/java/org/matomo/sdk/dispatcher/Dispatcher.java
+++ b/tracker/src/main/java/org/matomo/sdk/dispatcher/Dispatcher.java
@@ -57,11 +57,6 @@ public interface Dispatcher {
     DispatchMode getDispatchMode();
 
     /**
-     * Override the connectivity of the Dispatcher and handle all events as if the device is offline.
-     */
-    void setOffline();
-
-    /**
      * Starts the dispatcher for one cycle if it is currently not working.
      * If the dispatcher is working it will skip the dispatch interval once.
      */

--- a/tracker/src/main/java/org/matomo/sdk/dispatcher/Dispatcher.java
+++ b/tracker/src/main/java/org/matomo/sdk/dispatcher/Dispatcher.java
@@ -63,6 +63,13 @@ public interface Dispatcher {
     boolean forceDispatch();
 
     /**
+     * Dispatch all events in the EventCache and return only after the dispatch is complete.
+     *
+     * This method may be invoked while the Runtime is being torn down and should not start new threads.
+     */
+    void forceDispatchBlocking();
+
+    /**
      * To clear the dispatchers queue
      */
     void clear();

--- a/tracker/src/main/java/org/matomo/sdk/dispatcher/Dispatcher.java
+++ b/tracker/src/main/java/org/matomo/sdk/dispatcher/Dispatcher.java
@@ -57,6 +57,11 @@ public interface Dispatcher {
     DispatchMode getDispatchMode();
 
     /**
+     * Override the connectivity of the Dispatcher and handle all events as if the device is offline.
+     */
+    void setOffline();
+
+    /**
      * Starts the dispatcher for one cycle if it is currently not working.
      * If the dispatcher is working it will skip the dispatch interval once.
      */

--- a/tracker/src/main/java/org/matomo/sdk/extra/MatomoExceptionHandler.java
+++ b/tracker/src/main/java/org/matomo/sdk/extra/MatomoExceptionHandler.java
@@ -13,6 +13,7 @@ import android.support.annotation.Nullable;
 import org.matomo.sdk.Matomo;
 import org.matomo.sdk.TrackMe;
 import org.matomo.sdk.Tracker;
+import org.matomo.sdk.dispatcher.DispatchMode;
 
 import timber.log.Timber;
 
@@ -52,7 +53,7 @@ public class MatomoExceptionHandler implements Thread.UncaughtExceptionHandler {
             Tracker tracker = getTracker();
 
             // Force the tracker into offline mode to ensure events are written to disk
-            tracker.setOffline();
+            tracker.setDispatchMode(DispatchMode.EXCEPTION);
 
             TrackHelper.track(mTrackMe).exception(ex).description(excInfo).fatal(true).with(tracker);
 

--- a/tracker/src/main/java/org/matomo/sdk/extra/MatomoExceptionHandler.java
+++ b/tracker/src/main/java/org/matomo/sdk/extra/MatomoExceptionHandler.java
@@ -51,10 +51,10 @@ public class MatomoExceptionHandler implements Thread.UncaughtExceptionHandler {
 
             Tracker tracker = getTracker();
 
-            TrackHelper.track(mTrackMe).exception(ex).description(excInfo).fatal(true).with(tracker);
-
             // Force the tracker into offline mode to ensure events are written to disk
             tracker.setOffline();
+
+            TrackHelper.track(mTrackMe).exception(ex).description(excInfo).fatal(true).with(tracker);
 
             // Immediately dispatch as the app might be dying after rethrowing the exception and block until the dispatch is completed
             tracker.dispatchBlocking();

--- a/tracker/src/test/java/org/matomo/sdk/TrackerTest.java
+++ b/tracker/src/test/java/org/matomo/sdk/TrackerTest.java
@@ -159,22 +159,57 @@ public class TrackerTest {
     }
 
     @Test
-    public void testSetDispatchMode() {
+    public void testDispatchMode_default() {
+        mTrackerPreferences.edit().clear();
         Tracker tracker = new Tracker(mMatomo, mTrackerBuilder);
         assertEquals(DispatchMode.ALWAYS, tracker.getDispatchMode());
         verify(mDispatcher, times(1)).setDispatchMode(DispatchMode.ALWAYS);
+    }
 
+    @Test
+    public void testDispatchMode_change() {
+        Tracker tracker = new Tracker(mMatomo, mTrackerBuilder);
         tracker.setDispatchMode(DispatchMode.WIFI_ONLY);
         assertEquals(DispatchMode.WIFI_ONLY, tracker.getDispatchMode());
         verify(mDispatcher, times(1)).setDispatchMode(DispatchMode.WIFI_ONLY);
+    }
 
+    @Test
+    public void testDispatchMode_fallback() {
+        Tracker tracker = new Tracker(mMatomo, mTrackerBuilder);
         tracker.getPreferences().edit().putString(Tracker.PREF_KEY_DISPATCHER_MODE, "lol").apply();
         assertEquals(DispatchMode.ALWAYS, tracker.getDispatchMode());
-        verify(mDispatcher, times(2)).setDispatchMode(DispatchMode.ALWAYS);
+        verify(mDispatcher, times(1)).setDispatchMode(DispatchMode.ALWAYS);
+    }
 
+    @Test
+    public void testSetDispatchMode_propagation() {
+        mTrackerPreferences.edit().clear();
+        Tracker tracker = new Tracker(mMatomo, mTrackerBuilder);
+        verify(mDispatcher, times(1)).setDispatchMode(any());
+    }
+
+    @Test
+    public void testSetDispatchMode_propagation_change() {
+        mTrackerPreferences.edit().clear();
+        Tracker tracker = new Tracker(mMatomo, mTrackerBuilder);
+        tracker.setDispatchMode(DispatchMode.WIFI_ONLY);
         tracker.setDispatchMode(DispatchMode.WIFI_ONLY);
         assertEquals(DispatchMode.WIFI_ONLY, tracker.getDispatchMode());
         verify(mDispatcher, times(2)).setDispatchMode(DispatchMode.WIFI_ONLY);
+        verify(mDispatcher, times(3)).setDispatchMode(any());
+    }
+
+    @Test
+    public void testSetDispatchMode_exception() {
+        Tracker tracker = new Tracker(mMatomo, mTrackerBuilder);
+        tracker.setDispatchMode(DispatchMode.WIFI_ONLY); // This is persisted
+        tracker.setDispatchMode(DispatchMode.EXCEPTION); // This isn't
+        assertEquals(DispatchMode.EXCEPTION, tracker.getDispatchMode());
+        verify(mDispatcher, times(1)).setDispatchMode(DispatchMode.EXCEPTION);
+
+        tracker = new Tracker(mMatomo, mTrackerBuilder);
+        assertEquals(DispatchMode.WIFI_ONLY, tracker.getDispatchMode());
     }
 
     @Test

--- a/tracker/src/test/java/org/matomo/sdk/dispatcher/DefaultDispatcherTest.java
+++ b/tracker/src/test/java/org/matomo/sdk/dispatcher/DefaultDispatcherTest.java
@@ -345,7 +345,7 @@ public class DefaultDispatcherTest extends BaseTest {
     }
 
     @Test
-    public void testBlockingDispatchOffline() {
+    public void testBlockingDispatchExceptionMode() {
         mDispatcher.setDispatchInterval(200);
 
         final int threadCount = 5;
@@ -362,7 +362,7 @@ public class DefaultDispatcherTest extends BaseTest {
                 Packet packet = invocation.getArgument(0);
                 sentEvents.addAndGet(packet.getEventCount());
 
-                mDispatcher.setOffline();
+                mDispatcher.setDispatchMode(DispatchMode.EXCEPTION);
 
                 return true;
             }

--- a/tracker/src/test/java/org/matomo/sdk/dispatcher/DefaultDispatcherTest.java
+++ b/tracker/src/test/java/org/matomo/sdk/dispatcher/DefaultDispatcherTest.java
@@ -312,7 +312,7 @@ public class DefaultDispatcherTest extends BaseTest {
         final Semaphore lock = new Semaphore(0);
         final AtomicInteger eventCount = new AtomicInteger(0);
 
-        mDispatcher.setDispatchInterval(20);
+        mDispatcher.setDispatchInterval(-1);
 
         when(mPacketSender.send(any())).thenAnswer(new Answer<Boolean>() {
             @Override
@@ -328,11 +328,14 @@ public class DefaultDispatcherTest extends BaseTest {
             }
         });
 
-        final int threadCount = 5;
-        final int queryCount = 5;
+        final int threadCount = 7;
+        final int queryCount = 13;
         final List<String> createdEvents = Collections.synchronizedList(new ArrayList<>());
         launchTestThreads(mApiUrl, mDispatcher, threadCount, queryCount, createdEvents);
 
+        await().atMost(2, TimeUnit.SECONDS).until(() -> createdEvents.size(), is(threadCount * queryCount));
+
+        mDispatcher.forceDispatch();
 
         lock.acquire();
 

--- a/tracker/src/test/java/org/matomo/sdk/extra/TrackHelperTest.java
+++ b/tracker/src/test/java/org/matomo/sdk/extra/TrackHelperTest.java
@@ -498,6 +498,9 @@ public class TrackHelperTest {
         assertEquals(tracked.get(QueryParams.EVENT_NAME), "/ by zero");
         assertEquals(tracked.get(QueryParams.EVENT_VALUE), "1");
 
+        verify(mTracker).setOffline();
+        verify(mTracker).dispatchBlocking();
+
         boolean exception = false;
         try {
             track().uncaughtExceptions().with(mTracker);

--- a/tracker/src/test/java/org/matomo/sdk/extra/TrackHelperTest.java
+++ b/tracker/src/test/java/org/matomo/sdk/extra/TrackHelperTest.java
@@ -11,6 +11,7 @@ import org.matomo.sdk.Matomo;
 import org.matomo.sdk.QueryParams;
 import org.matomo.sdk.TrackMe;
 import org.matomo.sdk.Tracker;
+import org.matomo.sdk.dispatcher.DispatchMode;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -498,7 +499,7 @@ public class TrackHelperTest {
         assertEquals(tracked.get(QueryParams.EVENT_NAME), "/ by zero");
         assertEquals(tracked.get(QueryParams.EVENT_VALUE), "1");
 
-        verify(mTracker).setOffline();
+        verify(mTracker).setDispatchMode(DispatchMode.EXCEPTION);
         verify(mTracker).dispatchBlocking();
 
         boolean exception = false;


### PR DESCRIPTION
Resolves #249 

I added a way to force dispatch and block until complete as well as a method that forces events to disk.  It's not exactly what we discussed earlier.  I had to change some things to implement the feature without breaking existing api or function.

I wrote `Dispatcher.forceDispatchBlocking` to not start a new thread.  I was hoping I could make use of Java's `Runtime.addShutdownHook` to use this same logic when the app exits.  The documentation for `addShutdownHook` is pretty clear that creating a new Thread isn't supported in that mode.  Unfortunately, android doesn't call the runtime shutdown hooks before killing the app.  There isn't an opportunity to use that to cache events on app exit.  That said, writing it this way ensured the method returned as soon as possible.

I struggled a lot with the `setMode` method we talked about.  There is already  `Tracker.setDispatcherMode(ALWAYS/WIFI_ONLY)` but it persists the value to `SharedPreferences`.  This wasn't a good fit because forcing events to be written to disk isn't something that should be saved between sessions.

I tried to think of another mode setting that would expand to more than `DETECT` and `OFFLINE` and came up empty.  The more I thought about it the more sense it made to expose a `Tracker.setOffline()`.  I didn't create a getter or a way to re-enable the tracker because this is a terminal event.  It works well for this specific use case but I change how you trigger the offline mode if there is another use case it needs to support.

I made one change that affects the default behavior of the SDK.  I changed how the dispatch loop handles network events and connectivity changes.  The existing path assumed online until a packet failed to send.  After the packet failed the `EventCache` was set offline and events were re-queued.   This caused any events that occurred after the loop started to be written to disk while the rest remained in memory.  It seemed like all events should end up in memory or on disk based on the connectivity.

I changed the re-queuing logic to add unsent events back to the cache and then update the cache state with the current connectivity status.  This means a single network failure when the device is online generates no disk IO.  It also means that events are all written to disk as soon as the device looses its connectivity.

I built a local version of the SDK and tested it out on a few android devices. The logs show events are no longer lost on a crash.  The blocking dispatch returned almost instantly with 4 events + the crash in the queue.