### PR TITLE
Specify cookies for authenticated communication with Matomo APIs

### DIFF
--- a/exampleapp/src/main/java/org/matomo/demo/DemoApp.java
+++ b/exampleapp/src/main/java/org/matomo/demo/DemoApp.java
@@ -48,6 +48,9 @@ public class DemoApp extends MatomoApplication {
         // String userEmail = ....preferences....getString
         // getTracker().setUserId(userEmail);
 
+        // Set cookies, if your Matomo API is locked behind authorization
+        // getTracker().setCookie("Cookie1=value1; Cookie2=value2");
+
         // Track this app install, this will only trigger once per app version.
         // i.e. "http://org.matomo.demo:1/185DECB5CFE28FDB2F45887022D668B4"
         TrackHelper.track().download().identifier(new DownloadTracker.Extra.ApkChecksum(this)).with(getTracker());

--- a/tracker/build.gradle
+++ b/tracker/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 def versionMajor = 4
 def versionMinor = 1
-def versionPatch = 0
+def versionPatch = 1
 def myVersionCode = versionMajor * 10000 + versionMinor * 100 + versionPatch
 def myVersionName = "${versionMajor}.${versionMinor}.${versionPatch}"
 

--- a/tracker/src/main/java/org/matomo/sdk/Tracker.java
+++ b/tracker/src/main/java/org/matomo/sdk/Tracker.java
@@ -110,6 +110,15 @@ public class Tracker {
         mDefaultTrackMe.set(QueryParams.URL_PATH, config.getApplicationBaseUrl());
     }
 
+    /**
+     * Defines tracking request cookie, which may be necessary, if the API is behind authorization.
+     * @param cookie
+     */
+    public Tracker setCookie(String cookie) {
+        mDispatcher.setApiCookie(cookie);
+        return this;
+    }
+
     public void addTrackingCallback(Callback callback) {
         this.mTrackingCallbacks.add(callback);
     }

--- a/tracker/src/main/java/org/matomo/sdk/dispatcher/DefaultDispatcher.java
+++ b/tracker/src/main/java/org/matomo/sdk/dispatcher/DefaultDispatcher.java
@@ -278,4 +278,10 @@ public class DefaultDispatcher implements Dispatcher {
     public List<Packet> getDryRunTarget() {
         return mDryRunTarget;
     }
+
+    @Override
+    public Dispatcher setApiCookie(String cookie) {
+        mPacketFactory.setApiCookie(cookie);
+        return this;
+    }
 }

--- a/tracker/src/main/java/org/matomo/sdk/dispatcher/DefaultPacketSender.java
+++ b/tracker/src/main/java/org/matomo/sdk/dispatcher/DefaultPacketSender.java
@@ -27,6 +27,9 @@ public class DefaultPacketSender implements PacketSender {
         HttpURLConnection urlConnection = null;
         try {
             urlConnection = (HttpURLConnection) new URL(packet.getTargetURL()).openConnection();
+            if (packet.getTargetCookie() != null) {
+                urlConnection.setRequestProperty("Cookie", packet.getTargetCookie());
+            }
 
             Timber.tag(TAG).v("Connection is open to %s", urlConnection.getURL().toExternalForm());
             Timber.tag(TAG).v("Sending: %s", packet);

--- a/tracker/src/main/java/org/matomo/sdk/dispatcher/Dispatcher.java
+++ b/tracker/src/main/java/org/matomo/sdk/dispatcher/Dispatcher.java
@@ -91,4 +91,6 @@ public interface Dispatcher {
      * Mind thread-safety!
      */
     List<Packet> getDryRunTarget();
+
+    Dispatcher setApiCookie(String cookie);
 }

--- a/tracker/src/main/java/org/matomo/sdk/dispatcher/Packet.java
+++ b/tracker/src/main/java/org/matomo/sdk/dispatcher/Packet.java
@@ -19,12 +19,13 @@ public class Packet {
     private final JSONObject mPostData;
     private final long mTimeStamp;
     private final int mEventCount;
+    private final String mTargetCookie;
 
     /**
      * Constructor for GET requests
      */
-    public Packet(String targetURL) {
-        this(targetURL, null, 1);
+    public Packet(String targetURL, @Nullable String targetCookie) {
+        this(targetURL, targetCookie, null, 1);
     }
 
     /**
@@ -34,8 +35,9 @@ public class Packet {
      * @param JSONObject non null if HTTP POST packet
      * @param eventCount number of events in this packet
      */
-    public Packet(String targetURL, @Nullable JSONObject JSONObject, int eventCount) {
+    public Packet(String targetURL, @Nullable String targetCookie, @Nullable JSONObject JSONObject, int eventCount) {
         mTargetURL = targetURL;
+        mTargetCookie = targetCookie;
         mPostData = JSONObject;
         mEventCount = eventCount;
         mTimeStamp = System.currentTimeMillis();
@@ -43,6 +45,11 @@ public class Packet {
 
     public String getTargetURL() {
         return mTargetURL;
+    }
+
+    @Nullable
+    public String getTargetCookie() {
+        return mTargetCookie;
     }
 
     /**

--- a/tracker/src/main/java/org/matomo/sdk/dispatcher/PacketFactory.java
+++ b/tracker/src/main/java/org/matomo/sdk/dispatcher/PacketFactory.java
@@ -29,9 +29,15 @@ public class PacketFactory {
     @VisibleForTesting
     public static final int PAGE_SIZE = 20;
     private final String mApiUrl;
+    private String mApiCookie;
 
     public PacketFactory(final String apiUrl) {
         mApiUrl = apiUrl;
+    }
+
+    public PacketFactory setApiCookie(String cookie) {
+        this.mApiCookie = cookie;
+        return this;
     }
 
     public List<Packet> buildPackets(final List<Event> events) {
@@ -68,7 +74,7 @@ public class PacketFactory {
             JSONArray jsonArray = new JSONArray();
             for (Event event : events) jsonArray.put(event.getEncodedQuery());
             params.put("requests", jsonArray);
-            return new Packet(mApiUrl, params, events.size());
+            return new Packet(mApiUrl, mApiCookie, params, events.size());
         } catch (JSONException e) {
             Timber.tag(TAG).w(e, "Cannot create json object:\n%s", TextUtils.join(", ", events));
         }
@@ -79,7 +85,7 @@ public class PacketFactory {
     @Nullable
     private Packet buildPacketForGet(@NonNull Event event) {
         if (event.getEncodedQuery().isEmpty()) return null;
-        return new Packet(mApiUrl + event);
+        return new Packet(mApiUrl + event, mApiCookie);
     }
 
 }


### PR DESCRIPTION
We have a case, when we set up our own Matomo API and it has to be behind a corporate proxy. Our mobile app performs authentication, but Matomo communication did not use generated cookies. As a result, no request to the API was possible and no statistics were sent. I've added a way to provide cookies for use in that communication.
While this is a niche case, the modification is small and it may be of use to somebody else.