### PR TITLE
Only load preferences when needed and do not use them on MainThread

### DIFF
--- a/tracker/src/main/java/org/matomo/sdk/extra/InstallReferrerReceiver.java
+++ b/tracker/src/main/java/org/matomo/sdk/extra/InstallReferrerReceiver.java
@@ -3,7 +3,6 @@ package org.matomo.sdk.extra;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
 
 import org.matomo.sdk.Matomo;
 
@@ -34,12 +33,15 @@ public class InstallReferrerReceiver extends BroadcastReceiver {
             Timber.tag(TAG).d("Dropping forwarded intent");
             return;
         }
-        SharedPreferences preferences = Matomo.getInstance(context.getApplicationContext()).getPreferences();
         if (intent.getAction().equals(REFERRER_SOURCE_GPLAY)) {
             String referrer = intent.getStringExtra(ARG_KEY_GPLAY_REFERRER);
             if (referrer != null) {
-                preferences.edit().putString(PREF_KEY_INSTALL_REFERRER_EXTRAS, referrer).apply();
-                Timber.tag(TAG).d("Stored Google Play referrer extras: %s", referrer);
+                final PendingResult result = goAsync();
+                new Thread(() -> {
+                    Matomo.getInstance(context.getApplicationContext()).getPreferences().edit().putString(PREF_KEY_INSTALL_REFERRER_EXTRAS, referrer).apply();
+                    Timber.tag(TAG).d("Stored Google Play referrer extras: %s", referrer);
+                    result.finish();
+                }).start();
             }
         }
         // Forward to other possible recipients

--- a/tracker/src/test/java/org/matomo/sdk/extra/InstallReferrerReceiverTest.java
+++ b/tracker/src/test/java/org/matomo/sdk/extra/InstallReferrerReceiverTest.java
@@ -24,6 +24,7 @@ public class InstallReferrerReceiverTest extends DefaultTestCase {
         String testReferrerData1 = "utm_source=test_source&utm_medium=test_medium&utm_term=test_term&utm_content=test_content&utm_campaign=test_name";
         testIntent.putExtra(InstallReferrerReceiver.ARG_KEY_GPLAY_REFERRER, testReferrerData1);
         receiver.onReceive(Robolectric.application.getApplicationContext(), testIntent);
+        Thread.sleep(250);
         String referrerDataFromPreferences = getMatomo().getPreferences().getString(InstallReferrerReceiver.PREF_KEY_INSTALL_REFERRER_EXTRAS, null);
         assertEquals(testReferrerData1, referrerDataFromPreferences);
         assertTrue(testIntent.getBooleanExtra("forwarded", false));
@@ -33,12 +34,14 @@ public class InstallReferrerReceiverTest extends DefaultTestCase {
         testIntent.putExtra(InstallReferrerReceiver.ARG_KEY_GPLAY_REFERRER, testReferrerData2);
 
         receiver.onReceive(Robolectric.application.getApplicationContext(), testIntent);
+        Thread.sleep(250);
         referrerDataFromPreferences = getMatomo().getPreferences().getString(InstallReferrerReceiver.PREF_KEY_INSTALL_REFERRER_EXTRAS, null);
         assertEquals(testReferrerData1, referrerDataFromPreferences);
 
 
         testIntent.putExtra("forwarded", false);
         receiver.onReceive(Robolectric.application.getApplicationContext(), testIntent);
+        Thread.sleep(250);
         referrerDataFromPreferences = getMatomo().getPreferences().getString(InstallReferrerReceiver.PREF_KEY_INSTALL_REFERRER_EXTRAS, null);
         assertEquals(testReferrerData2, referrerDataFromPreferences);
     }
@@ -52,6 +55,7 @@ public class InstallReferrerReceiverTest extends DefaultTestCase {
         String testReferrerData1 = "utm_source=test_source&utm_medium=test_medium&utm_term=test_term&utm_content=test_content&utm_campaign=test_name";
         badIntent.putExtra(InstallReferrerReceiver.ARG_KEY_GPLAY_REFERRER, testReferrerData1);
         receiver.onReceive(Robolectric.application.getApplicationContext(), badIntent);
+        Thread.sleep(250);
         String referrerDataFromPreferences = getMatomo().getPreferences().getString(InstallReferrerReceiver.PREF_KEY_INSTALL_REFERRER_EXTRAS, null);
         assertNull(referrerDataFromPreferences);
 
@@ -62,6 +66,7 @@ public class InstallReferrerReceiverTest extends DefaultTestCase {
         testReferrerData1 = "utm_source=test_source&utm_medium=test_medium&utm_term=test_term&utm_content=test_content&utm_campaign=test_name";
         nullIntent.putExtra(InstallReferrerReceiver.ARG_KEY_GPLAY_REFERRER, testReferrerData1);
         receiver.onReceive(Robolectric.application.getApplicationContext(), nullIntent);
+        Thread.sleep(250);
         referrerDataFromPreferences = getMatomo().getPreferences().getString(InstallReferrerReceiver.PREF_KEY_INSTALL_REFERRER_EXTRAS, null);
         assertNull(referrerDataFromPreferences);
     }


### PR DESCRIPTION
Avoid startup slowdown / ANR.

Despite using apply, edit and put require the preferences to be fully loaded and as disk based can be slow or ANR when used on main thread.