### PR TITLE
Allow extending Matomo class

### DIFF
--- a/tracker/src/main/java/org/matomo/sdk/Matomo.java
+++ b/tracker/src/main/java/org/matomo/sdk/Matomo.java
@@ -46,7 +46,7 @@ public class Matomo {
         return sInstance;
     }
 
-    private Matomo(Context context) {
+    protected Matomo(Context context) {
         mContext = context.getApplicationContext();
         mBasePreferences = context.getSharedPreferences(BASE_PREFERENCE_FILE, Context.MODE_PRIVATE);
     }


### PR DESCRIPTION
Currently, the constructor of the `Matomo` class is `private` disallowing the extension and hence the modification of the class. This pull request changes the accessibility to `protected`.