### PR TITLE
Fix Device information only report for first session per process

### DIFF
--- a/tracker/src/main/java/org/matomo/sdk/Tracker.java
+++ b/tracker/src/main/java/org/matomo/sdk/Tracker.java
@@ -8,12 +8,14 @@
 package org.matomo.sdk;
 
 import android.content.SharedPreferences;
+
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
 import org.matomo.sdk.dispatcher.DispatchMode;
 import org.matomo.sdk.dispatcher.Dispatcher;
 import org.matomo.sdk.dispatcher.Packet;
+import org.matomo.sdk.tools.DeviceHelper;
 import org.matomo.sdk.tools.Objects;
 
 import java.text.SimpleDateFormat;
@@ -100,13 +102,15 @@ public class Tracker {
 
         mDefaultTrackMe.set(QueryParams.SESSION_START, DEFAULT_TRUE_VALUE);
 
+        DeviceHelper deviceHelper = mMatomo.getDeviceHelper();
+
         String resolution = DEFAULT_UNKNOWN_VALUE;
-        int[] res = mMatomo.getDeviceHelper().getResolution();
+        int[] res = deviceHelper.getResolution();
         if (res != null) resolution = String.format("%sx%s", res[0], res[1]);
         mDefaultTrackMe.set(QueryParams.SCREEN_RESOLUTION, resolution);
 
-        mDefaultTrackMe.set(QueryParams.USER_AGENT, mMatomo.getDeviceHelper().getUserAgent());
-        mDefaultTrackMe.set(QueryParams.LANGUAGE, mMatomo.getDeviceHelper().getUserLanguage());
+        mDefaultTrackMe.set(QueryParams.USER_AGENT, deviceHelper.getUserAgent());
+        mDefaultTrackMe.set(QueryParams.LANGUAGE, deviceHelper.getUserLanguage());
         mDefaultTrackMe.set(QueryParams.URL_PATH, config.getApplicationBaseUrl());
     }
 

--- a/tracker/src/main/java/org/matomo/sdk/Tracker.java
+++ b/tracker/src/main/java/org/matomo/sdk/Tracker.java
@@ -379,24 +379,25 @@ public class Tracker {
         long visitCount;
         long previousVisit;
 
+        SharedPreferences prefs = getPreferences();
         // Protected against Trackers on other threads trying to do the same thing.
         // This works because they would use the same preference object.
-        synchronized (getPreferences()) {
+        //noinspection SynchronizationOnLocalVariableOrMethodParameter
+        synchronized (prefs) {
+            SharedPreferences.Editor editor = prefs.edit();
             visitCount = 1 + getPreferences().getLong(PREF_KEY_TRACKER_VISITCOUNT, 0);
-            getPreferences().edit().putLong(PREF_KEY_TRACKER_VISITCOUNT, visitCount).apply();
-        }
+            editor.putLong(PREF_KEY_TRACKER_VISITCOUNT, visitCount);
 
-        synchronized (getPreferences()) {
-            firstVisitTime = getPreferences().getLong(PREF_KEY_TRACKER_FIRSTVISIT, -1);
+            firstVisitTime = prefs.getLong(PREF_KEY_TRACKER_FIRSTVISIT, -1);
             if (firstVisitTime == -1) {
                 firstVisitTime = System.currentTimeMillis() / 1000;
-                getPreferences().edit().putLong(PREF_KEY_TRACKER_FIRSTVISIT, firstVisitTime).apply();
+                editor.putLong(PREF_KEY_TRACKER_FIRSTVISIT, firstVisitTime);
             }
-        }
 
-        synchronized (getPreferences()) {
-            previousVisit = getPreferences().getLong(PREF_KEY_TRACKER_PREVIOUSVISIT, -1);
-            getPreferences().edit().putLong(PREF_KEY_TRACKER_PREVIOUSVISIT, System.currentTimeMillis() / 1000).apply();
+            previousVisit = prefs.getLong(PREF_KEY_TRACKER_PREVIOUSVISIT, -1);
+            editor.putLong(PREF_KEY_TRACKER_PREVIOUSVISIT, System.currentTimeMillis() / 1000);
+
+            editor.apply();
         }
 
         // trySet because the developer could have modded these after creating the Tracker


### PR DESCRIPTION
As discussed in #309 this addresses the issue of the fingerprint parameters not being added for new sessions, causing "unknown" and "Generic" device information

Also there are some additional commits for minor cleanup of Tracker.java