### PR TITLE
Release job and automatic changelog

### DIFF
--- a/.github/changelog-configuration.json
+++ b/.github/changelog-configuration.json
@@ -1,0 +1,32 @@
+{
+  "categories": [
+    {
+      "title": "## 💡 Features",
+      "labels": [
+        "feature",
+        "enhancement"
+      ]
+    },
+    {
+      "title": "## 🐛 Fixes",
+      "labels": [
+        "fix",
+        "bug"
+      ]
+    },
+    {
+      "title": "## 💬 Maintenance",
+      "labels": [
+        "maintenance"
+      ]
+    }
+  ],
+  "ignore_labels": [
+    "dependencies",
+    "gradle-wrapper"
+  ],
+  "sort": "ASC",
+  "template": "${{CHANGELOG}}",
+  "pr_template": "- ${{TITLE}} #${{NUMBER}}",
+  "empty_template": "- no changes"
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Changelog vs Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Build Changelog
+        id: github_release
+        uses: mikepenz/release-changelog-builder-action@main
+        with:
+          configuration: ".github/changelog-configuration.json"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install JDK ${{ matrix.java_version }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: 11
+      - name: Build project
+        run: ./gradlew assembleRelease
+        env:
+          VERSION: ${{ github.ref }}
+      - name: Get the version
+        id: tagger
+        uses: jimschubert/query-tag-action@v2
+        with:
+          skip-unshallow: 'true'
+          abbrev: false
+          commit-ish: HEAD
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{steps.tagger.outputs.tag}}
+          name: ${{steps.tagger.outputs.tag}}
+          body: ${{steps.github_release.outputs.changelog}}
+          files: touchview/build/outputs/aar/touchview-release.aar
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
A new release needs now only a new tag, eg
```
git tag -a 1.0 -m "text"
git push --tags
```

Then the release pipeline starts and generates a changelog, depended on labels of pull request.
This means a label on pull request makes sense now, if you want to see it in release changelog,

All is untested and copy&paste from https://github.com/MikeOrtiz/TouchImageView where it works like this