### PR TITLE
Add an option to set okHttpClient

### DIFF
--- a/tracker/build.gradle
+++ b/tracker/build.gradle
@@ -23,6 +23,8 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation "com.jakewharton.timber:timber:${timberVersion}"
 
+    implementation "com.squareup.okhttp3:okhttp:3.12.+"
+
     testImplementation 'org.awaitility:awaitility:3.0.0'
     testImplementation 'androidx.test:core:1.4.0'
     // Robolectric

--- a/tracker/src/main/java/org/matomo/sdk/Tracker.java
+++ b/tracker/src/main/java/org/matomo/sdk/Tracker.java
@@ -25,6 +25,8 @@ import java.util.regex.Pattern;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
+
+import okhttp3.OkHttpClient;
 import timber.log.Timber;
 
 
@@ -56,6 +58,7 @@ public class Tracker {
     private static final Pattern VALID_URLS = Pattern.compile("^(\\w+)(?:://)(.+?)$");
 
     private final Matomo mMatomo;
+    private final OkHttpClient mClient;
     private final String mApiUrl;
     private final int mSiteId;
     private final String mDefaultApplicationBaseUrl;
@@ -79,6 +82,7 @@ public class Tracker {
         mApiUrl = config.getApiUrl();
         mSiteId = config.getSiteId();
         mName = config.getTrackerName();
+        mClient = config.getOkHttpClient();
         mDefaultApplicationBaseUrl = config.getApplicationBaseUrl();
 
         new LegacySettingsPorter(mMatomo).port(this);
@@ -527,6 +531,14 @@ public class Tracker {
      */
     public void setDryRunTarget(List<Packet> dryRunTarget) {
         mDispatcher.setDryRunTarget(dryRunTarget);
+    }
+
+    /**
+     * return the OkHttpClient to use
+     * @return OkHttpClient
+     */
+    public OkHttpClient getOkHttpClient() {
+         return mClient;
     }
 
     /**

--- a/tracker/src/main/java/org/matomo/sdk/TrackerBuilder.java
+++ b/tracker/src/main/java/org/matomo/sdk/TrackerBuilder.java
@@ -3,6 +3,8 @@ package org.matomo.sdk;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import okhttp3.OkHttpClient;
+
 /**
  * Configuration details for a {@link Tracker}
  */
@@ -11,6 +13,7 @@ public class TrackerBuilder {
     private int mSiteId;
     private String mTrackerName;
     private String mApplicationBaseUrl;
+    private OkHttpClient mClient;
 
     public static TrackerBuilder createDefault(String apiUrl, int siteId) {
         return new TrackerBuilder(apiUrl, siteId, "Default Tracker");
@@ -63,6 +66,18 @@ public class TrackerBuilder {
         return this;
     }
 
+    /**
+     * set okHttp3 client to use instead of default http implementation
+     * @param client an OKHttpClient to use
+     */
+    public void setOkHttpClient(OkHttpClient client) {
+        mClient = client;
+    }
+
+    public OkHttpClient getOkHttpClient() {
+        return mClient;
+    }
+
     public String getApplicationBaseUrl() {
         return mApplicationBaseUrl;
     }
@@ -91,5 +106,4 @@ public class TrackerBuilder {
         result = 31 * result + mTrackerName.hashCode();
         return result;
     }
-
 }

--- a/tracker/src/main/java/org/matomo/sdk/dispatcher/DefaultDispatcherFactory.java
+++ b/tracker/src/main/java/org/matomo/sdk/dispatcher/DefaultDispatcherFactory.java
@@ -5,11 +5,18 @@ import org.matomo.sdk.tools.Connectivity;
 
 public class DefaultDispatcherFactory implements DispatcherFactory {
     public Dispatcher build(Tracker tracker) {
+        PacketSender packetSender;
+        if (tracker.getOkHttpClient()!= null) {
+            packetSender = new DefaultPacketSender();
+        } else {
+            packetSender = new OkHttpPacketSender(tracker.getOkHttpClient());
+        }
+
         return new DefaultDispatcher(
                 new EventCache(new EventDiskCache(tracker)),
                 new Connectivity(tracker.getMatomo().getContext()),
                 new PacketFactory(tracker.getAPIUrl()),
-                new DefaultPacketSender()
+                packetSender
         );
     }
 }

--- a/tracker/src/main/java/org/matomo/sdk/dispatcher/OkHttpPacketSender.java
+++ b/tracker/src/main/java/org/matomo/sdk/dispatcher/OkHttpPacketSender.java
@@ -1,0 +1,71 @@
+package org.matomo.sdk.dispatcher;
+
+import org.matomo.sdk.Matomo;
+
+import java.net.HttpURLConnection;
+
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import timber.log.Timber;
+
+public class OkHttpPacketSender implements PacketSender {
+
+    private static final String TAG = Matomo.tag(OkHttpPacketSender.class);
+    private long mTimeout = Dispatcher.DEFAULT_CONNECTION_TIMEOUT;
+    private boolean mGzip = true;
+    private final OkHttpClient mClient;
+
+    public OkHttpPacketSender(OkHttpClient client) {
+        mClient = client;
+    }
+
+    @Override
+    public boolean send(Packet packet) {
+        Request.Builder reqBuilder = new Request.Builder()
+                .url(packet.getTargetURL());
+
+        Timber.tag(TAG).d("sending matomo packet");
+        if (packet.getPostData() != null) {
+            RequestBody body = RequestBody.create(
+                    MediaType.get("application/json; charset=urf-8"),
+                    packet.getPostData().toString()
+            );
+            reqBuilder.post(body);
+        } else {
+            reqBuilder.get();
+        }
+
+        Request request = reqBuilder.build();
+
+        boolean isSuccessful;
+        Response res = null;
+        try {
+            res = mClient.newCall(request).execute();
+            isSuccessful = res.code() == HttpURLConnection.HTTP_NO_CONTENT || res.code() == HttpURLConnection.HTTP_OK;
+            Timber.tag(TAG).d("matomo packet sent successfully");
+            Timber.tag(TAG).d("status code: " + res.code());
+        } catch (Exception e) {
+            isSuccessful = false;
+
+            Timber.tag(TAG).e(e, "matomo packet sent failed");
+        } finally {
+            if (res != null) {
+                res.close();
+            }
+        }
+        return isSuccessful;
+    }
+
+    @Override
+    public void setTimeout(long timeout) {
+        mTimeout = timeout;
+    }
+
+    @Override
+    public void setGzipData(boolean gzip) {
+        mGzip = gzip;
+    }
+}


### PR DESCRIPTION
Add an option to set okHttpClient to the tracker and use it without writing the entire dispatcher (uses default dispatcher)


