### PR TITLE
Update example app with new demo server

### DIFF
--- a/exampleapp/src/main/java/org/matomo/demo/DemoApp.java
+++ b/exampleapp/src/main/java/org/matomo/demo/DemoApp.java
@@ -21,7 +21,7 @@ public class DemoApp extends MatomoApplication {
 
     @Override
     public TrackerBuilder onCreateTrackerConfig() {
-        return TrackerBuilder.createDefault("https://demo.matomo.org/matomo.php", 53);
+        return TrackerBuilder.createDefault("https://demo2.matomo.org/matomo.php", 81);
     }
 
     @Override


### PR DESCRIPTION
The previous one was lost? when it went `Piwik` -> `Matomo`.

The new one is `demo2.matomo.org`, ID `81`.

@hannesa2 You should have gotten an invite with admin access to the server. Might have been flagged as spam?