### PR TITLE
Avoid clearing dispatcher when user changes optOut setting

### DIFF
--- a/tracker/src/main/java/org/matomo/sdk/Tracker.java
+++ b/tracker/src/main/java/org/matomo/sdk/Tracker.java
@@ -164,7 +164,6 @@ public class Tracker {
     public void setOptOut(boolean optOut) {
         mOptOut = optOut;
         getPreferences().edit().putBoolean(PREF_KEY_TRACKER_OPTOUT, optOut).apply();
-        mDispatcher.clear();
     }
 
     /**

--- a/tracker/src/test/java/org/matomo/sdk/TrackerTest.java
+++ b/tracker/src/test/java/org/matomo/sdk/TrackerTest.java
@@ -234,7 +234,6 @@ public class TrackerTest {
     public void testOptOut_set() {
         Tracker tracker = new Tracker(mMatomo, mTrackerBuilder);
         tracker.setOptOut(true);
-        verify(mDispatcher).clear();
         assertTrue(tracker.isOptOut());
         tracker.setOptOut(false);
         assertFalse(tracker.isOptOut());


### PR DESCRIPTION
PR fixes #474 

Basically setting setting setOptOut always clears dispatcher. It should set only flag and events should be omitted, not cleared. 