### PR TITLE
Add license to artifact

### DIFF
--- a/tracker/build.gradle
+++ b/tracker/build.gradle
@@ -86,7 +86,16 @@ publishing {
     publications {
         release(MavenPublication) {
             afterEvaluate {
-                from components.release
+                from components.release {
+                    pom {
+                        licenses {
+                            license {
+                                name = 'BSD 3-Clause "New" or "Revised" License'
+                                url = 'https://github.com/matomo-org/matomo-sdk-android/blob/master/LICENSE'
+                            }
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
close #503 

Now you see the [license](https://github.com/matomo-org/matomo-sdk-android/blob/master/LICENSE) included in pom file,


e.g https://jitpack.io/com/github/matomo-org/matomo-sdk-android/LicenseInArtifact-4.2-ga8abad6-20/matomo-sdk-android-LicenseInArtifact-4.2-ga8abad6-20.pom

![image](https://github.com/matomo-org/matomo-sdk-android/assets/3314607/49d86c05-a559-474d-9a90-8f7bfa22530f)
