### PR TITLE
Declare Timber directly instead of via LogcatCoreLib

### DIFF
--- a/tracker/build.gradle
+++ b/tracker/build.gradle
@@ -31,7 +31,7 @@ android {
 
 dependencies {
     implementation "androidx.annotation:annotation:1.9.1"
-    implementation "com.github.AppDevNext.Logcat:LogcatCoreLib:3.4"
+    implementation "com.jakewharton.timber:timber:5.0.1"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 
     testImplementation "org.awaitility:awaitility:4.3.0"


### PR DESCRIPTION
### What

Replaces the `LogcatCoreLib` dependency of the `tracker` module with a direct dependency on Timber.

```diff
- implementation "com.github.AppDevNext.Logcat:LogcatCoreLib:3.4"
+ implementation "com.jakewharton.timber:timber:5.0.1"
```

### Why

The tracker uses Timber for its logging (67 call sites across 16 files) but never declares it — Timber
arrives transitively, because `LogcatCoreLib` exposes it at `compile` scope. No class from
`info.hannes.*` is referenced anywhere in `tracker/src/main`, so the library itself is unused here.

Declaring Timber directly makes that dependency explicit and drops four transitive artifacts from
every app that integrates the SDK:

```
com.github.AppDevNext.Logcat:LogcatCoreLib:3.4
├── com.jakewharton.timber:timber:5.0.1          <- the only one actually used
├── org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2
├── androidx.lifecycle:lifecycle-runtime-ktx:2.9.3
├── androidx.lifecycle:lifecycle-livedata-ktx:2.9.3
└── org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.2.10
```

For apps that ship an open source attribution screen, each of those also means one more entry to
track and keep licensed — which is how we noticed.

`5.0.1` is the version that was already being resolved transitively, so the Timber version on the
classpath does not change.

### Scope

The `exampleapp` module keeps `LogcatCoreLib`: it genuinely uses it (`DemoApp.kt` installs
`info.hannes.timber.DebugFormatTree`). This change only touches the published `tracker` module.

### Verification

Ran the same steps as the PR CI, all green:

- `./gradlew assembleDebug`
- `./gradlew check` — 454 tests, 0 failures
- `./gradlew :tracker:assembleRelease`
